### PR TITLE
fix: Include source maps in dist

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -21,4 +21,4 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Update dist
-        file_pattern: dist/index.js
+        file_pattern: dist/*

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -21,4 +21,4 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Update dist
-        file_pattern: dist/*
+        file_pattern: dist/index.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "ncc build",
+    "package": "ncc build --source-map --license licenses.txt",
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
-    "package": "ncc build --source-map --license licenses.txt",
+    "package": "ncc build",
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },


### PR DESCRIPTION
The update-dist workflow is rebuilding the dist but only committing the index.js file, which results in a missing source map dep

```
Error: Cannot find module './sourcemap-register.js'
```

I don't think we need a source map, but open to it if there's a case for it.
