### PR TITLE
fix: Ensure source-ref is truly optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Copy a tflint configuration file from a remote repository to use locally with `t
 | --- | --- | --- |
 | `source-repo` | (Required) The repository from which the configuration will be copied. Format: `owner/name` ||
 | `source-path` | Path to the configuration file in the remote repository | `.tflint.hcl` |
-| `source-ref` | Ref or branch of the remote repository to target | `main` |
+| `source-ref` | Ref or branch of the remote repository to target | |
 | `destination-path` | Path where configuration file will be written locally | `$HOME/.tflint.hcl` |
 | `token` | Github personal access token, [required](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#granting-additional-permissions) for reading from private repositories.  ||
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,6 @@ inputs:
     default: .tflint.hcl
   source-ref:
     description: Ref or branch of the remote repository to target
-    default: ''
   destination-path:
     description: Path where configuration file will be written locally. (Default $HOME/.tflint.hcl)
   token:

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -10,8 +10,8 @@ interface CopyFileParameters {
   owner: string
   repo: string
   srcPath: string
-  ref: string
   dstPath: string
+  ref?: string
   token?: string
 }
 
@@ -31,10 +31,13 @@ export async function copyFile({
     owner,
     repo,
     path: srcPath,
-    ref
+    ...(ref ? {ref} : {})
   })) as {data: GetContentDataType}
 
-  await fs.promises.writeFile(dstPath, Buffer.from(data.content, 'base64').toString('utf8'))
+  await fs.promises.writeFile(
+    dstPath,
+    Buffer.from(data.content, 'base64').toString('utf8')
+  )
 
   return dstPath
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,9 @@ async function run(): Promise<void> {
         repo,
         srcPath: core.getInput('source-path'),
         ref: core.getInput('source-ref'),
-        dstPath: core.getInput('destination-path') || path.join(os.homedir(), '.tflint.hcl'),
+        dstPath:
+          core.getInput('destination-path') ||
+          path.join(os.homedir(), '.tflint.hcl'),
         token: core.getInput('token')
       })
     )


### PR DESCRIPTION
When leaving source-ref blank:

```
Run terraform-linters/tflint-load-config-action@main
  with:
    source-repo: TakeScoop/tflint-config
    source-path: .tflint.hcl
Error: No commit found for the ref 
```

This ensures that if no source-ref is passed, we can let github decide what the branch should be