### PR TITLE
`node12` -> `node16`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
   path:
     description: The local path to the TFLint configuration file
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
We need to use node16 instead of node12.
GitHub officially announced that Node 12 has been out of support.

refs:
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-using-nodejs-v16