### PR TITLE
github: use `actions/setup-node`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: |
           npm install
       - run: |

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -8,12 +8,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.head_ref }}
-    - uses: actions/cache@v2
+    - uses: actions/setup-node@v3
       with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        node-version: 16
+        cache: npm
     - name: Install dependencies
       run: npm ci
     - name: Update dist


### PR DESCRIPTION
Previously the Node version implicitly available in the Actions environment was used. Instead, this explicitly configures a node version. This action can also handle caching without the need to call `actions/cache` directly.