### PR TITLE
test: set `token` to avoid rate limiting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,5 @@ jobs:
           npm ci
       - run: |
           npm run all
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prevents rate limiting by passing a token. The implementation is unnecessary awkward/hacky, see #94. We should be calling the action itself and passing `token` in `with`. In the mean time, this simulates how a token is passed to actions.