### PR TITLE
github: read `runs.using` node version for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - id: node-version
+        uses: bendrucker/github-action-node-version@v1
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: ${{ steps.node-version.outputs.version }}
           cache: npm
       - run: |
           npm ci

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -8,9 +8,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+      - id: node-version
+        uses: bendrucker/github-action-node-version@v1
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: ${{ steps.node-version.outputs.version }}
           cache: npm
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Eliminates the possibility of the test and build processes getting out of sync with the Node version used at runtime.