### PR TITLE
action: run on `node20`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
   path:
     description: The local path to the TFLint configuration file
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Instructs GitHub to use Node.js v20 to run the action. Closes #159.