### PR TITLE
Pin GitHub Action versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install yamlfmt
         run: |
           cd "$(mktemp -d)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
   test: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: node-version
-        uses: bendrucker/github-action-node-version@v1
-      - uses: actions/setup-node@v4
+        uses: bendrucker/github-action-node-version@2b4cda19381b8015197f9a3eff1ec934716241da # v1.0.0
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ steps.node-version.outputs.version }}
           cache: npm

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -5,12 +5,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
       - id: node-version
-        uses: bendrucker/github-action-node-version@v1
-      - uses: actions/setup-node@v4
+        uses: bendrucker/github-action-node-version@2b4cda19381b8015197f9a3eff1ec934716241da # v1.0.0
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ steps.node-version.outputs.version }}
           cache: npm
@@ -18,7 +18,7 @@ jobs:
         run: npm ci
       - name: Update dist
         run: npm run build && npm run package
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
         with:
           commit_message: Update dist
           file_pattern: dist/*

--- a/.github/workflows/update-semver.yml
+++ b/.github/workflows/update-semver.yml
@@ -9,5 +9,5 @@ jobs:
   update-semver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: haya14busa/action-update-semver@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: haya14busa/action-update-semver@fb48464b2438ae82cc78237be61afb4f461265a1 # v1.2.1


### PR DESCRIPTION
See also https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup

This PR makes GitHub Actions hash-pinned to reduce the risk of similar incidents.
Run `pinact run` with v1.4.0.
https://github.com/suzuki-shunsuke/pinact