### PR TITLE
build(deps): Group eslint updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,12 @@ updates:
       actions:
         patterns:
           - "@actions/*"
+      eslint:
+        patterns:
+          - eslint
+          - eslint-*
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - typescript-eslint
     cooldown:
       default-days: 5


### PR DESCRIPTION
eslint majors move their plugins' peer ranges with them, so dependabot bumping `eslint` alone produces a PR that cannot install. That is what happened with #243: `eslint@10` against `eslint-plugin-github@^6.0.0` (peer `^8 || ^9`) failed `npm ci`, and landing it took a hand-written #247 bumping both.

Grouping `eslint`, `eslint-*`, `@eslint/*`, `@typescript-eslint/*`, and `typescript-eslint` lets dependabot open one PR whose members resolve against each other. The last three match nothing in `package.json` today and are there so a future migration off `eslint-plugin-github` doesn't silently fall out of the group.
